### PR TITLE
Remove unused setting operator name

### DIFF
--- a/src/scripts/bc-view-manager.js
+++ b/src/scripts/bc-view-manager.js
@@ -444,10 +444,8 @@ bc.ViewManager = function(formBuilder) {
 			messageElement = $operatorMessageTemplate.cloneNode(true);
 
 			var operatorTitle = document.getElementById("bc-title-operator");
-			var operatorName = document.getElementById("bc-title-operator-name");
 			var operatorAvatar = document.getElementById("bc-title-operator-avatar");
 			bc.util.removeClass(operatorTitle, 'bc-hidden');
-			bc.util.setText(operatorName, name);
 			if(avatar) {
 				bc.util.setText(operatorAvatar, avatar);
 			}


### PR DESCRIPTION
This is what through me off when I was trying to figure out how to set the message writer... name isn't even passed into this function.  So to not through off others might as well just remove the useless code.
