### PR TITLE
made bc namespace real "global"

### DIFF
--- a/src/scripts/bc-api-frame.js
+++ b/src/scripts/bc-api-frame.js
@@ -1,4 +1,4 @@
-var bc = bc || {};
+var bc = window.bc = (window.bc || {});
 
 /**
  * @typedef {(object)} iframeElement

--- a/src/scripts/bc-client.js
+++ b/src/scripts/bc-client.js
@@ -39,8 +39,7 @@
  success (result) - The results on success
  failure (message) - The message on failure
  */
-var bc = window.bc || {};
-window.bc = bc;
+var bc = window.bc = (window.bc || {});
 //var bc = bc || {};
 //
 //bc.initializeClientVars = function() {

--- a/src/scripts/bc-config.js
+++ b/src/scripts/bc-config.js
@@ -4,7 +4,7 @@
  */
 
 
-var bc = bc || {};
+var bc = window.bc = (window.bc || {});
 
 (function() {
 

--- a/src/scripts/bc-form-builder.js
+++ b/src/scripts/bc-form-builder.js
@@ -1,4 +1,4 @@
-var bc = bc || {};
+var bc = window.bc = (window.bc || {});
 
 /**
  *  @typedef {(object)} FormBuilder

--- a/src/scripts/bc-localizer.js
+++ b/src/scripts/bc-localizer.js
@@ -1,4 +1,4 @@
-var bc = bc || {};
+var bc = window.bc = (window.bc || {});
 
 /**
  * An instance of {@link bc.Localizer}

--- a/src/scripts/bc-person-type.js
+++ b/src/scripts/bc-person-type.js
@@ -1,4 +1,4 @@
-var bc = bc || {};
+var bc = window.bc = (window.bc || {});
 
 /**
  *  @typedef {(object)} PersonType

--- a/src/scripts/bc-popup.js
+++ b/src/scripts/bc-popup.js
@@ -1,4 +1,4 @@
-var bc = bc || {};
+var bc = window.bc = (window.bc || {});
 
 bc.setConfig = function(config, chatParams, visitInfo) {
 	var configCookieValue = bc.util.readCookie(bc.config.configCookie);

--- a/src/scripts/bc-sdk-start.js
+++ b/src/scripts/bc-sdk-start.js
@@ -1,4 +1,4 @@
-var bc = bc || {};
+var bc = window.bc = (window.bc || {});
 
 bc.startSession = function(chatParams, visitInfo, hideChatWindow) {
 	'use strict';

--- a/src/scripts/bc-session-state.js
+++ b/src/scripts/bc-session-state.js
@@ -1,4 +1,4 @@
-var bc = bc || {};
+var bc = window.bc = (window.bc || {});
 
 /**
  *  @typedef {(object)} SessionState

--- a/src/scripts/bc-session-storage.js
+++ b/src/scripts/bc-session-storage.js
@@ -1,4 +1,4 @@
-var bc = window.bc || {};
+var bc = window.bc = (window.bc || {});
 
 /**
  * Creates a session storage instance for storing messages for faster chat window rebuild on page transitions.

--- a/src/scripts/bc-session.js
+++ b/src/scripts/bc-session.js
@@ -1,5 +1,5 @@
 /** @namespace */
-var bc = bc || {};
+var bc = window.bc = (window.bc || {});
 
 /**
  * An instance of {@link bc.Session}

--- a/src/scripts/bc-util.js
+++ b/src/scripts/bc-util.js
@@ -1,4 +1,4 @@
-var bc = bc || {};
+var bc = window.bc = (window.bc || {});
 
 bc.util = bc.util || {};
 

--- a/src/scripts/bc-view-manager.js
+++ b/src/scripts/bc-view-manager.js
@@ -1,4 +1,4 @@
-var bc = bc || {};
+var bc = window.bc = (window.bc || {});
 
 /**
  *  @typedef {(object)} ViewManager


### PR DESCRIPTION
Hi, guys!
Could you please make your sdk components real "global"?

We are using sdk with webpack and require
For example
```
require('./bc-config');
```
But unfortunately, this way doesnt work, because every sdk component uses global bc namespace, whitch is not global in case of require
```
var bc = bc || {};
```
This way doesnt take bc from global scope as default. So we need to do something like this for every file

```
var bc = window.bc = (window.bc || {});
```
Actually, that is what you did for `bc-client.js` file; And that is how it should work in other files imho :)

What do you think?

Thx for great SDK from Nanorep team :+1: 